### PR TITLE
Fix header for the output table when the Ip address is IPv6

### DIFF
--- a/scripts/ipintutil
+++ b/scripts/ipintutil
@@ -193,9 +193,13 @@ def get_ip_intfs_in_namespace(af, namespace, display):
     return ip_intfs
 
 
-def display_ip_intfs(ip_intfs):
+def display_ip_intfs(ip_intfs,address_family):
     header = ['Interface', 'Master', 'IPv4 address/mask',
               'Admin/Oper', 'BGP Neighbor', 'Neighbor IP']
+
+    if address_family == 'ipv6':
+        header[2] = 'IPv6 address/mask'
+    
     data = []
     for ip_intf, v in natsorted(ip_intfs.items()):
         ip_address = v['ipaddr'][0][1]
@@ -265,7 +269,7 @@ def main():
 
     load_db_config()
     ip_intfs = get_ip_intfs(af, namespace, display)
-    display_ip_intfs(ip_intfs)
+    display_ip_intfs(ip_intfs,args.address_family)
 
     sys.exit(0)
 

--- a/tests/show_ip_int_test.py
+++ b/tests/show_ip_int_test.py
@@ -19,7 +19,7 @@ PortChannel0001            30.1.1.1/24          error/down    T0-Peer         30
 Vlan100                    40.1.1.1/24          error/down    N/A             N/A"""
 
 show_ipv6_intf_with_multiple_ips = """\
-Interface        Master    IPv4 address/mask                             Admin/Oper    BGP Neighbor    Neighbor IP
+Interface        Master    IPv6 address/mask                             Admin/Oper    BGP Neighbor    Neighbor IP
 ---------------  --------  --------------------------------------------  ------------  --------------  -------------
 Ethernet0                  2100::1/64                                    error/down    N/A             N/A
                            aa00::1/64                                                  N/A             N/A
@@ -36,7 +36,7 @@ Loopback0                  40.1.1.1/32          error/down    N/A             N/
 PortChannel0001            20.1.1.1/24          error/down    T2-Peer         20.1.1.5"""
 
 show_multi_asic_ipv6_intf = """\
-Interface        Master    IPv4 address/mask                       Admin/Oper    BGP Neighbor    Neighbor IP
+Interface        Master    IPv6 address/mask                       Admin/Oper    BGP Neighbor    Neighbor IP
 ---------------  --------  --------------------------------------  ------------  --------------  -------------
 Loopback0                  fe80::60a5:9dff:fef4:1696%Loopback0/64  error/down    N/A             N/A
 PortChannel0001            aa00::1/64                              error/down    N/A             N/A
@@ -54,7 +54,7 @@ veth@eth1                  192.1.1.1/24         error/down    N/A             N/
 veth@eth2                  193.1.1.1/24         error/down    N/A             N/A"""
 
 show_multi_asic_ipv6_intf_all = """\
-Interface        Master    IPv4 address/mask                       Admin/Oper    BGP Neighbor    Neighbor IP
+Interface        Master    IPv6 address/mask                       Admin/Oper    BGP Neighbor    Neighbor IP
 ---------------  --------  --------------------------------------  ------------  --------------  -------------
 Loopback0                  fe80::60a5:9dff:fef4:1696%Loopback0/64  error/down    N/A             N/A
 PortChannel0001            aa00::1/64                              error/down    N/A             N/A


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fix the header for "show ipv6 interface" output that display "IPv4" instead of "IPv6"

#### How I did it

#### How to verify it

Run "show ip interface" CLi command and verify that the output header present "IPv4"
Run "show ipv6 interface" CLi command and verify that the output header present "IPv6"

#### Previous command output (if the output of a command-line utility has changed)

```
root@r-bulldog-03:/usr/local/bin# show ipv6 int
Interface    Master    IPv4 address/mask                        Admin/Oper    BGP Neighbor    Neighbor IP
-----------  --------  ---------------------------------------  ------------  --------------  -------------
Bridge                 fe80::c76:fbff:fec6:86c5%Bridge/64       up/down       N/A             N/A
Ethernet0              fe80::ee0d:9aff:fe60:3900%Ethernet0/64   up/up         N/A             N/A
Ethernet4              fe80::ee0d:9aff:fe60:3900%Ethernet4/64   up/up         N/A             N/A
Ethernet8              fe80::ee0d:9aff:fe60:3900%Ethernet8/64   up/up         N/A             N/A
Ethernet12             fe80::ee0d:9aff:fe60:3900%Ethernet12/64  up/up         N/A             N/A
Ethernet14             fe80::ee0d:9aff:fe60:3900%Ethernet14/64  up/up         N/A             N/A
Ethernet16             fe80::ee0d:9aff:fe60:3900%Ethernet16/64  up/up         N/A             N/A
Ethernet18             fe80::ee0d:9aff:fe60:3900%Ethernet18/64  up/up         N/A             N/A
Ethernet20             fe80::ee0d:9aff:fe60:3900%Ethernet20/64  up/up         N/A             N/A
Ethernet21             fe80::ee0d:9aff:fe60:3900%Ethernet21/64  up/up         N/A             N/A
Ethernet22             fe80::ee0d:9aff:fe60:3900%Ethernet22/64  up/up         N/A             N/A
Ethernet23             fe80::ee0d:9aff:fe60:3900%Ethernet23/64  up/up         N/A             N/A
Ethernet24             fe80::ee0d:9aff:fe60:3900%Ethernet24/64  up/up         N/A             N/A
Ethernet25             fe80::ee0d:9aff:fe60:3900%Ethernet25/64  up/up         N/A             N/A
Ethernet26             fe80::ee0d:9aff:fe60:3900%Ethernet26/64  up/up         N/A             N/A
Ethernet27             fe80::ee0d:9aff:fe60:3900%Ethernet27/64  up/up         N/A             N/A
Ethernet28             fe80::ee0d:9aff:fe60:3900%Ethernet28/64  up/up         N/A             N/A
Ethernet32             fe80::ee0d:9aff:fe60:3900%Ethernet32/64  up/up         N/A             N/A
Ethernet36             fe80::ee0d:9aff:fe60:3900%Ethernet36/64  up/up         N/A             N/A
Ethernet40             fe80::ee0d:9aff:fe60:3900%Ethernet40/64  up/up         N/A             N/A
Ethernet44             fe80::ee0d:9aff:fe60:3900%Ethernet44/64  up/up         N/A             N/A
Ethernet48             fe80::ee0d:9aff:fe60:3900%Ethernet48/64  up/up         N/A             N/A
Ethernet52             fe80::ee0d:9aff:fe60:3900%Ethernet52/64  up/up         N/A             N/A
Ethernet56             fe80::ee0d:9aff:fe60:3900%Ethernet56/64  up/up         N/A             N/A
Ethernet60             fe80::ee0d:9aff:fe60:3900%Ethernet60/64  up/up         N/A             N/A
docker0                fd00::1/80                               up/down       N/A             N/A
                       fe80::1%docker0/64                                     N/A             N/A
eth0                   fe80::ee0d:9aff:fead:864%eth0/64         up/up         N/A             N/A
lo                     ::1/128                                  up/up         N/A             N/A
```



#### New command output (if the output of a command-line utility has changed)

```
root@r-bulldog-03:/usr/local/bin# show ipv6 int
Interface    Master    IPv6 address/mask                        Admin/Oper    BGP Neighbor    Neighbor IP
-----------  --------  ---------------------------------------  ------------  --------------  -------------
Bridge                 fe80::c76:fbff:fec6:86c5%Bridge/64       up/down       N/A             N/A
Ethernet0              fe80::ee0d:9aff:fe60:3900%Ethernet0/64   up/up         N/A             N/A
Ethernet4              fe80::ee0d:9aff:fe60:3900%Ethernet4/64   up/up         N/A             N/A
Ethernet8              fe80::ee0d:9aff:fe60:3900%Ethernet8/64   up/up         N/A             N/A
Ethernet12             fe80::ee0d:9aff:fe60:3900%Ethernet12/64  up/up         N/A             N/A
Ethernet14             fe80::ee0d:9aff:fe60:3900%Ethernet14/64  up/up         N/A             N/A
Ethernet16             fe80::ee0d:9aff:fe60:3900%Ethernet16/64  up/up         N/A             N/A
Ethernet18             fe80::ee0d:9aff:fe60:3900%Ethernet18/64  up/up         N/A             N/A
Ethernet20             fe80::ee0d:9aff:fe60:3900%Ethernet20/64  up/up         N/A             N/A
Ethernet21             fe80::ee0d:9aff:fe60:3900%Ethernet21/64  up/up         N/A             N/A
Ethernet22             fe80::ee0d:9aff:fe60:3900%Ethernet22/64  up/up         N/A             N/A
Ethernet23             fe80::ee0d:9aff:fe60:3900%Ethernet23/64  up/up         N/A             N/A
Ethernet24             fe80::ee0d:9aff:fe60:3900%Ethernet24/64  up/up         N/A             N/A
Ethernet25             fe80::ee0d:9aff:fe60:3900%Ethernet25/64  up/up         N/A             N/A
Ethernet26             fe80::ee0d:9aff:fe60:3900%Ethernet26/64  up/up         N/A             N/A
Ethernet27             fe80::ee0d:9aff:fe60:3900%Ethernet27/64  up/up         N/A             N/A
Ethernet28             fe80::ee0d:9aff:fe60:3900%Ethernet28/64  up/up         N/A             N/A
Ethernet32             fe80::ee0d:9aff:fe60:3900%Ethernet32/64  up/up         N/A             N/A
Ethernet36             fe80::ee0d:9aff:fe60:3900%Ethernet36/64  up/up         N/A             N/A
Ethernet40             fe80::ee0d:9aff:fe60:3900%Ethernet40/64  up/up         N/A             N/A
Ethernet44             fe80::ee0d:9aff:fe60:3900%Ethernet44/64  up/up         N/A             N/A
Ethernet48             fe80::ee0d:9aff:fe60:3900%Ethernet48/64  up/up         N/A             N/A
Ethernet52             fe80::ee0d:9aff:fe60:3900%Ethernet52/64  up/up         N/A             N/A
Ethernet56             fe80::ee0d:9aff:fe60:3900%Ethernet56/64  up/up         N/A             N/A
Ethernet60             fe80::ee0d:9aff:fe60:3900%Ethernet60/64  up/up         N/A             N/A
docker0                fd00::1/80                               up/down       N/A             N/A
                       fe80::1%docker0/64                                     N/A             N/A
eth0                   fe80::ee0d:9aff:fead:864%eth0/64         up/up         N/A             N/A
lo                     ::1/128                                  up/up         N/A             N/A

```