### PR TITLE
[Mellanox] Update SDK sniffer default target folder

### DIFF
--- a/config/plugins/mlnx.py
+++ b/config/plugins/mlnx.py
@@ -42,7 +42,7 @@ ENV_VARIABLE_SX_SNIFFER = 'SX_SNIFFER_ENABLE'
 ENV_VARIABLE_SX_SNIFFER_TARGET = 'SX_SNIFFER_TARGET'
 
 # SDK sniffer file path and name
-SDK_SNIFFER_TARGET_PATH = '/var/log/mellanox/sniffer/'
+SDK_SNIFFER_TARGET_PATH = '/var/log/sdk_dbg/'
 SDK_SNIFFER_FILENAME_PREFIX = 'sx_sdk_sniffer_'
 SDK_SNIFFER_FILENAME_EXT = '.pcap'
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Change the target path for SDK Sniffer from "/var/log/mellanox/sniffer/" To: "/var/log/sdk_dbg"



#### How I did it

Change the default for SDK_SNIFFER_TARGET_PATH

#### How to verify it

Run SDK sniffer and make sure the sniffer output file kept in the new location

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

