### PR TITLE
Limit PFC WD Detection time to maximum value of 1000[ms]

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -417,12 +417,13 @@ class PfcwdCli(object):
 
         port_num = len(list(self.config_db.get_table('PORT').keys()))
 
+        # Paramter values positively correlate to the number of ports.
+        multiply = max(1, (port_num-1)//DEFAULT_PORT_NUM+1)
+
         pfc_wd_detected_time = DEFAULT_DETECTION_TIME * multiply
         if pfc_wd_detected_time > MAX_DETECTION_TIME:
             pfc_wd_detected_time = MAX_DETECTION_TIME
         
-        # Paramter values positively correlate to the number of ports.
-        multiply = max(1, (port_num-1)//DEFAULT_PORT_NUM+1)
         pfcwd_info = {
             'detection_time': pfc_wd_detected_time,
             'restoration_time': DEFAULT_RESTORATION_TIME * multiply,

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -345,7 +345,7 @@ class PfcwdCli(object):
         pfcwd_info = {}
         if poll_interval is not None:
             pfcwd_table = self.config_db.get_table(CONFIG_DB_PFC_WD_TABLE_NAME)
-            entry_min = 3000
+            entry_min = MAX_DETECTION_TIME
             for entry in pfcwd_table:
                 if("Ethernet" not in entry):
                     continue
@@ -526,7 +526,7 @@ class Start(object):
 # Set WD poll interval
 class Interval(object):
     @cli.command()
-    @click.argument('poll_interval', type=click.IntRange(100, 3000))
+    @click.argument('poll_interval', type=click.IntRange(100, MAX_DETECTION_TIME))
     @clicommon.pass_db
     def interval(db, poll_interval):
         """ Set PFC watchdog counter polling interval """

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -33,6 +33,7 @@ except KeyError:
     pass
 
 # Default configuration
+MAX_DETECTION_TIME = 1000
 DEFAULT_DETECTION_TIME = 200
 DEFAULT_RESTORATION_TIME = 200
 DEFAULT_POLL_INTERVAL = 200
@@ -416,10 +417,14 @@ class PfcwdCli(object):
 
         port_num = len(list(self.config_db.get_table('PORT').keys()))
 
+        pfc_wd_detected_time = DEFAULT_DETECTION_TIME * multiply
+        if pfc_wd_detected_time > MAX_DETECTION_TIME:
+            pfc_wd_detected_time = MAX_DETECTION_TIME
+        
         # Paramter values positively correlate to the number of ports.
         multiply = max(1, (port_num-1)//DEFAULT_PORT_NUM+1)
         pfcwd_info = {
-            'detection_time': DEFAULT_DETECTION_TIME * multiply,
+            'detection_time': pfc_wd_detected_time,
             'restoration_time': DEFAULT_RESTORATION_TIME * multiply,
             'action': DEFAULT_ACTION,
             'pfc_stat_history': DEFAULT_PFC_HISTORY_STATUS


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

PFC WD Detection time is defined by the following calculation:

DEFAULT_POLL_INTERVAL * multiply

where:

* multiply = max(1, (port_num-1)//DEFAULT_PORT_NUM+1)
* port_num = len(list(self.config_db.get_table('PORT').keys()))
* DEFAULT_POLL_INTERVAL = 200
* DEFAULT_PORT_NUM = 32

There is an allowed range for this value which is between 100..3000 [ms].
For system with more than 448 ports, we will violate this range. 

In addition, there is no meaning to have detection time of more than 1000[ms], hence, this change limit the maximum detection time for PFC WD to 1000[ms]

#### How I did it

Calculate PFC WD Detection time, if it become bigger than 1000[ms], set it to 1000[ms]

#### How to verify it

Run PFC WD Tests on several platforms

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

